### PR TITLE
Persist favorites selection on back navigation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".activity.MainActivity"
-            android:label="@string/app_name">
+            android:label="@string/app_name"
+            android:launchMode="singleTop">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         <activity
             android:name=".activity.MainActivity"
             android:label="@string/app_name"
-            android:launchMode="singleTop">
+            android:launchMode="singleTop"
+            android:configChanges="orientation">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/udacity/popularmovies/activity/DetailActivity.java
+++ b/app/src/main/java/com/udacity/popularmovies/activity/DetailActivity.java
@@ -69,7 +69,7 @@ public class DetailActivity extends AppCompatActivity {
             public boolean onTouch(View v, MotionEvent event) {
                 if (event.getAction() == MotionEvent.ACTION_UP) {
                     DataUtils.toggleIsFavorite(context, selectedMovie);
-                    Log.d(TAG, "Tagging movieId " + selectedMovie.getId() +
+                    Log.d(TAG, "Tagging movieId " + selectedMovie.getMovieId() +
                             " as favorite: " + selectedMovie.getIsFavorite(context));
                     mFavoriteStar.setImageResource(selectedMovie.getIsFavorite(context) ?
                             R.drawable.enabled_star :
@@ -80,7 +80,7 @@ public class DetailActivity extends AppCompatActivity {
         });
 
         // Grab associated trailer videos and reviews via movieId
-        int movieId = selectedMovie.getId();
+        int movieId = selectedMovie.getMovieId();
         Bundle bundle = new Bundle();
         bundle.putInt(MOVIE_ID_EXTRA, movieId);
 

--- a/app/src/main/java/com/udacity/popularmovies/activity/DetailActivity.java
+++ b/app/src/main/java/com/udacity/popularmovies/activity/DetailActivity.java
@@ -8,6 +8,7 @@ import android.util.Log;
 import android.view.MotionEvent;
 import android.view.View;
 import android.widget.ImageView;
+import android.widget.ScrollView;
 import android.widget.TextView;
 
 import com.squareup.picasso.Picasso;
@@ -23,6 +24,8 @@ public class DetailActivity extends AppCompatActivity {
     private static final String MOVIE = "movie";
     private static final String MOVIE_ID_EXTRA = "movieId";
 
+    private ScrollView mScrollView;
+
     private ImageView mBackdrop;
     private TextView mTitle;
     private ImageView mPoster;
@@ -35,6 +38,10 @@ public class DetailActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_detail);
+
+        mScrollView = findViewById(R.id.detail_activity_scrollview);
+        mScrollView.smoothScrollTo(0, 0);
+        Log.d(TAG, "Setting scrollview to top");
 
         // find all views of activity
         mBackdrop = findViewById(R.id.iv_backdrop);

--- a/app/src/main/java/com/udacity/popularmovies/activity/MainActivity.java
+++ b/app/src/main/java/com/udacity/popularmovies/activity/MainActivity.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
+import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
@@ -38,6 +39,7 @@ public class MainActivity
 
     public static final String MOVIE = "movie";
     public static final String SORT_BY_EXTRA = "sortBy";
+    public static final String SCROLL_POSITION_EXTRA = "scrollPosition";
 
     private static final int MOVIE_SORT_LOADER = 22;
 
@@ -46,6 +48,7 @@ public class MainActivity
 
     private AutofitRecyclerView mRecyclerView;
     private MovieAdapter mMovieAdapter;
+    private Parcelable mListState;
 
     private TextView mErrorMessage;
     private ProgressBar mLoadingIndicator;
@@ -107,8 +110,7 @@ public class MainActivity
         FragmentManager fragmentManager = getSupportFragmentManager();
         if (mFavoriteFragment == null) {
             mFavoriteFragment = new FavoriteFragment();
-            getSupportFragmentManager()
-                    .beginTransaction()
+            fragmentManager.beginTransaction()
                     .add(R.id.favorites_fragment_placeholder, mFavoriteFragment)
                     .commit();
         } else {
@@ -270,5 +272,27 @@ public class MainActivity
         super.onSaveInstanceState(outState);
         // Save the sort based on what was selected in the menu
         outState.putSerializable(SORT_BY_EXTRA, mSort);
+        // Save the scroll position in the AutofitRecyclerView
+        // Resource: https://stackoverflow.com/questions/28236390/recyclerview-store-restore-state-between-activities
+        Parcelable mListState = mRecyclerView.getLayoutManager().onSaveInstanceState();
+        outState.putParcelable(SCROLL_POSITION_EXTRA, mListState);
+    }
+
+    @Override
+    protected void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+        if (savedInstanceState != null) {
+            mListState = savedInstanceState.getParcelable(SCROLL_POSITION_EXTRA);
+        }
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        if (mListState != null) {
+            mRecyclerView
+                    .getLayoutManager()
+                    .onRestoreInstanceState(mListState);
+        }
     }
 }

--- a/app/src/main/java/com/udacity/popularmovies/activity/MainActivity.java
+++ b/app/src/main/java/com/udacity/popularmovies/activity/MainActivity.java
@@ -290,9 +290,7 @@ public class MainActivity
     protected void onResume() {
         super.onResume();
         if (mListState != null) {
-            mRecyclerView
-                    .getLayoutManager()
-                    .onRestoreInstanceState(mListState);
+            mRecyclerView.getLayoutManager().onRestoreInstanceState(mListState);
         }
     }
 }

--- a/app/src/main/java/com/udacity/popularmovies/adapter/FavoriteAdapter.java
+++ b/app/src/main/java/com/udacity/popularmovies/adapter/FavoriteAdapter.java
@@ -85,7 +85,6 @@ public class FavoriteAdapter extends RecyclerView.Adapter<FavoriteAdapter.Favori
     @Override
     public void onBindViewHolder(@NonNull FavoriteAdapterViewHolder holder, int position) {
         Movie selectedMovie = getMovieFromCursor(position);
-        Log.d(TAG, "onBindViewHolder movie: " + selectedMovie);
         Picasso.with(mContext)
                 .load(selectedMovie.getPosterImageUrl())
                 .placeholder(R.drawable.movie_placeholder)

--- a/app/src/main/java/com/udacity/popularmovies/adapter/FavoriteAdapter.java
+++ b/app/src/main/java/com/udacity/popularmovies/adapter/FavoriteAdapter.java
@@ -54,7 +54,7 @@ public class FavoriteAdapter extends RecyclerView.Adapter<FavoriteAdapter.Favori
                         final int adapterPosition = getAdapterPosition();
                         Movie selectedMovie = getMovieFromCursor(adapterPosition);
                         DataUtils.toggleIsFavorite(mContext, selectedMovie);
-                        Log.d(TAG, "Tagging movieId " + selectedMovie.getId() +
+                        Log.d(TAG, "Tagging movieId " + selectedMovie.getMovieId() +
                                 " as favorite: " + selectedMovie.getIsFavorite(mContext));
                         notifyItemChanged(adapterPosition);
                     }

--- a/app/src/main/java/com/udacity/popularmovies/adapter/MovieAdapter.java
+++ b/app/src/main/java/com/udacity/popularmovies/adapter/MovieAdapter.java
@@ -50,7 +50,7 @@ public class MovieAdapter extends RecyclerView.Adapter<MovieAdapter.MovieAdapter
                         final int adapterPosition = getAdapterPosition();
                         Movie selectedMovie = movies[adapterPosition];
                         DataUtils.toggleIsFavorite(mContext, selectedMovie);
-                        Log.d(TAG, "Tagging movieId " + selectedMovie.getId() +
+                        Log.d(TAG, "Tagging movieId " + selectedMovie.getMovieId() +
                                 " as favorite: " + selectedMovie.getIsFavorite(mContext));
                         notifyItemChanged(adapterPosition);
                     }

--- a/app/src/main/java/com/udacity/popularmovies/model/Movie.java
+++ b/app/src/main/java/com/udacity/popularmovies/model/Movie.java
@@ -10,7 +10,7 @@ public final class Movie implements Parcelable {
     private static final String IMAGE_BASE_URL = "http://image.tmdb.org/t/p/";
     private static final String IMAGE_DEFAULT_POSTER_SIZE = "w185";
 
-    private int id;
+    private int movieId;
     private String title;
     private String backdropPath;
     private String posterPath;
@@ -18,9 +18,9 @@ public final class Movie implements Parcelable {
     private String releaseDate;
     private String voteAvg;
 
-    public Movie(int id, String title, String backdropPath, String posterPath,
+    public Movie(int movieId, String title, String backdropPath, String posterPath,
                  String summary, String releaseDate, String voteAvg) {
-        this.id = id;
+        this.movieId = movieId;
         this.title = title;
         this.backdropPath = backdropPath;
         this.posterPath = posterPath;
@@ -31,7 +31,7 @@ public final class Movie implements Parcelable {
 
     // Note: Must read from parcel in same order contents were added
     public Movie(Parcel source) {
-        id = source.readInt();
+        movieId = source.readInt();
         title = source.readString();
         backdropPath = source.readString();
         posterPath = source.readString();
@@ -40,8 +40,8 @@ public final class Movie implements Parcelable {
         voteAvg = source.readString();
     }
 
-    public int getId() {
-        return id;
+    public int getMovieId() {
+        return movieId;
     }
 
     public String getTitle() {
@@ -77,7 +77,7 @@ public final class Movie implements Parcelable {
     }
 
     public boolean getIsFavorite(Context context) {
-        return DataUtils.getFavorite(context, id);
+        return DataUtils.getFavorite(context, movieId);
     }
 
     @Override
@@ -87,7 +87,7 @@ public final class Movie implements Parcelable {
 
     @Override
     public void writeToParcel(Parcel dest, int flags) {
-        dest.writeInt(id);
+        dest.writeInt(movieId);
         dest.writeString(title);
         dest.writeString(backdropPath);
         dest.writeString(posterPath);

--- a/app/src/main/java/com/udacity/popularmovies/utilities/DataUtils.java
+++ b/app/src/main/java/com/udacity/popularmovies/utilities/DataUtils.java
@@ -19,7 +19,7 @@ public class DataUtils {
     public static boolean toggleIsFavorite(Context context, Movie movie) {
         boolean isFavorite = movie.getIsFavorite(context);
         if (isFavorite) {
-            removeFavorite(context, movie.getId());
+            removeFavorite(context, movie.getMovieId());
         } else {
             addFavorite(context, movie);
         }
@@ -28,7 +28,7 @@ public class DataUtils {
 
     private static Uri addFavorite(Context context, Movie movie) {
         ContentValues contentValues = new ContentValues();
-        contentValues.put(FavoriteEntry.COLUMN_MOVIE_ID, movie.getId());
+        contentValues.put(FavoriteEntry.COLUMN_MOVIE_ID, movie.getMovieId());
         contentValues.put(FavoriteEntry.COLUMN_TITLE, movie.getTitle());
         contentValues.put(FavoriteEntry.COLUMN_BACKDROP_PATH, movie.getBackdropPath());
         contentValues.put(FavoriteEntry.COLUMN_POSTER_PATH, movie.getPosterPath());

--- a/app/src/main/java/com/udacity/popularmovies/utilities/JsonUtils.java
+++ b/app/src/main/java/com/udacity/popularmovies/utilities/JsonUtils.java
@@ -13,7 +13,7 @@ import org.json.JSONObject;
 public class JsonUtils {
 
     private static final String RESULTS = "results";
-    private static final String ID = "id";
+    private static final String MOVIE_ID = "id";
     private static final String TITLE = "title";
     private static final String BACKDROP_IMAGE_PATH = "backdrop_path";
     private static final String POSTER_IMAGE_PATH = "poster_path";
@@ -37,20 +37,16 @@ public class JsonUtils {
     }
 
     public static Movie parseMovieJson(JSONObject json) {
-        try {
-            final int id = json.getInt(ID);
-            final String title = json.getString(TITLE);
-            final String backdropImagePath = json.getString(BACKDROP_IMAGE_PATH);
-            final String posterImagePath = json.getString(POSTER_IMAGE_PATH);
-            final String summary = json.getString(SUMMARY);
-            final String releaseDate = json.getString(RELEASE_DATE);
-            final String voteAvg = json.getString(VOTE_AVG);
+        final int movieId = json.optInt(MOVIE_ID);
+        final String title = json.optString(TITLE);
+        final String backdropImagePath = json.optString(BACKDROP_IMAGE_PATH);
+        final String posterImagePath = json.optString(POSTER_IMAGE_PATH);
+        final String summary = json.optString(SUMMARY);
+        final String releaseDate = json.optString(RELEASE_DATE);
+        final String voteAvg = json.optString(VOTE_AVG);
 
-            return new Movie(id, title, backdropImagePath, posterImagePath,
-                    summary, releaseDate, voteAvg);
-        } catch (JSONException e) {
-            return null;
-        }
+        return new Movie(movieId, title, backdropImagePath, posterImagePath,
+                summary, releaseDate, voteAvg);
     }
 
     public static String[] parseVideosFromJsonString(String json) throws JSONException {
@@ -59,7 +55,7 @@ public class JsonUtils {
         String[] result = new String[videos.length()];
         for (int i = 0; i < videos.length(); i++) {
             JSONObject video = (JSONObject) videos.get(i);
-            result[i] = video.getString(VIDEO_KEY);
+            result[i] = video.optString(VIDEO_KEY);
         }
         return result;
     }
@@ -76,13 +72,9 @@ public class JsonUtils {
     }
 
     public static Review parseReviewJson(JSONObject json) {
-        try {
-            final String content = json.getString(REVIEW_CONTENT);
-            final String author = json.getString(REVIEW_AUTHOR);
+        final String content = json.optString(REVIEW_CONTENT);
+        final String author = json.optString(REVIEW_AUTHOR);
 
-            return new Review(content, author);
-        } catch (JSONException e) {
-            return null;
-        }
+        return new Review(content, author);
     }
 }

--- a/app/src/main/res/layout/activity_detail.xml
+++ b/app/src/main/res/layout/activity_detail.xml
@@ -2,13 +2,13 @@
 
 <ScrollView xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/detail_activity_scrollview"
     android:layout_height="wrap_content"
-    android:layout_width="match_parent"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+    android:layout_width="match_parent">
 
     <android.support.constraint.ConstraintLayout
         xmlns:app="http://schemas.android.com/apk/res-auto"
-        xmlns:tools="http://schemas.android.com/tools"
         android:orientation="vertical"
         android:layout_width="match_parent"
         android:layout_height="match_parent">

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,7 +7,7 @@
         android:id="@+id/recyclerview_movie"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:columnWidth="200dp" />
+        android:columnWidth="@dimen/autofit_rv_columnWidth" />
 
     <FrameLayout
         android:id="@+id/favorites_fragment_placeholder"
@@ -18,16 +18,11 @@
         android:id="@+id/tv_error_message"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="16dp"
-        android:text="@string/error_message"
-        android:textSize="20sp"
-        android:visibility="invisible" />
+        style="@style/ErrorMessageText"
+        android:text="@string/error_message" />
 
     <ProgressBar
         android:id="@+id/pb_loading_indicator"
-        android:layout_width="42dp"
-        android:layout_height="42dp"
-        android:layout_gravity="center"
-        android:visibility="invisible" />
+        style="@style/LoadingIndicator" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/favorite_fragment.xml
+++ b/app/src/main/res/layout/favorite_fragment.xml
@@ -7,7 +7,7 @@
         android:id="@+id/recyclerview_favorite"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:columnWidth="200dp" />
+        android:columnWidth="@dimen/autofit_rv_columnWidth" />
 
     <TextView
         android:id="@+id/tv_no_favorites"
@@ -15,13 +15,10 @@
         android:layout_height="wrap_content"
         android:text="@string/no_favorites"
         android:visibility="invisible"
-        android:layout_marginTop="8dp" />
+        android:layout_marginTop="@dimen/no_content_marginTop" />
 
     <ProgressBar
         android:id="@+id/pb_favorite_loading_indicator"
-        android:layout_width="42dp"
-        android:layout_height="42dp"
-        android:layout_gravity="center"
-        android:visibility="invisible" />
+        style="@style/LoadingIndicator" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/review_fragment.xml
+++ b/app/src/main/res/layout/review_fragment.xml
@@ -6,8 +6,7 @@
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recyclerview_review"
         android:layout_width="match_parent"
-        android:layout_height="200dp"
-        android:layout_marginTop="24dp" />
+        style="@style/FragmentScroll" />
 
     <TextView
         android:id="@+id/tv_no_reviews"
@@ -15,13 +14,10 @@
         android:layout_height="wrap_content"
         android:text="@string/no_reviews"
         android:visibility="invisible"
-        android:layout_marginTop="8dp" />
+        android:layout_marginTop="@dimen/no_content_marginTop" />
 
     <ProgressBar
         android:id="@+id/pb_review_loading_indicator"
-        android:layout_width="42dp"
-        android:layout_height="42dp"
-        android:layout_gravity="center"
-        android:visibility="invisible" />
+        style="@style/LoadingIndicator" />
 
 </FrameLayout>

--- a/app/src/main/res/layout/trailer_fragment.xml
+++ b/app/src/main/res/layout/trailer_fragment.xml
@@ -6,9 +6,8 @@
     <ListView
         android:id="@+id/listview_trailer"
         android:layout_width="match_parent"
-        android:layout_height="200dp"
-        android:layout_marginTop="24dp"
-        android:layout_marginBottom="36dp" />
+        style="@style/FragmentScroll"
+        android:layout_marginBottom="@dimen/fragment_rv_marginBottom" />
 
     <TextView
         android:id="@+id/tv_no_trailers"
@@ -16,13 +15,10 @@
         android:layout_height="wrap_content"
         android:text="@string/no_trailers"
         android:visibility="invisible"
-        android:layout_marginTop="8dp" />
+        android:layout_marginTop="@dimen/no_content_marginTop" />
 
     <ProgressBar
         android:id="@+id/pb_trailer_loading_indicator"
-        android:layout_width="42dp"
-        android:layout_height="42dp"
-        android:layout_gravity="center"
-        android:visibility="invisible" />
+        style="@style/LoadingIndicator" />
 
 </FrameLayout>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,21 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <!-- MainActivity -->
+
+    <dimen name="autofit_rv_columnWidth">200dp</dimen>
+
+    <dimen name="loading_indicator_size">42dp</dimen>
+
+    <dimen name="no_content_marginTop">8dp</dimen>
+
+    <!-- DetailActivity -->
+
     <dimen name="title_bar_height">100dp</dimen>
 
-    <dimen name="title_text_size">36dp</dimen>
-    <dimen name="title_text_paddingLeft">12dp</dimen>
+    <dimen name="title_textSize">36dp</dimen>
+    <dimen name="title_paddingLeft">12dp</dimen>
+
+    <dimen name="error_message_padding">16dp</dimen>
+    <dimen name="error_message_textSize">20sp</dimen>
+
+    <dimen name="default_margin">36dp</dimen>
 
     <dimen name="poster_layout_width">160dp</dimen>
     <dimen name="poster_layout_height">215dp</dimen>
-    <dimen name="poster_layout_marginLeft">36dp</dimen>
-    <dimen name="poster_layout_marginStart">36dp</dimen>
     <dimen name="poster_layout_marginTop">28dp</dimen>
 
     <dimen name="favorite_star_layout_width">48dp</dimen>
     <dimen name="favorite_star_layout_height">48dp</dimen>
-    <dimen name="favorite_star_layout_marginEnd">36dp</dimen>
-    <dimen name="favorite_star_layout_marginRight">36dp</dimen>
-    <dimen name="favorite_star_layout_marginTop">36dp</dimen>
 
     <dimen name="movie_info_text_width">132dp</dimen>
     <dimen name="movie_info_text_height">40dp</dimen>
@@ -24,19 +34,12 @@
     <dimen name="movie_info_text_marginTop">28dp</dimen>
 
     <dimen name="summary_layout_marginBottom">8dp</dimen>
-    <dimen name="summary_layout_marginLeft">36dp</dimen>
-    <dimen name="summary_layout_marginStart">36dp</dimen>
-    <dimen name="summary_layout_marginRight">36dp</dimen>
-    <dimen name="summary_layout_marginEnd">36dp</dimen>
     <dimen name="summary_layout_marginTop">24dp</dimen>
 
-    <dimen name="fragment_header_layout_marginLeft">36dp</dimen>
-    <dimen name="fragment_header_layout_marginStart">36dp</dimen>
     <dimen name="fragment_header_layout_marginTop">24dp</dimen>
     <dimen name="fragment_header_textSize">24dp</dimen>
 
-    <dimen name="fragment_layout_marginLeft">36dp</dimen>
-    <dimen name="fragment_layout_marginStart">36dp</dimen>
-    <dimen name="fragment_layout_marginRight">36dp</dimen>
-    <dimen name="fragment_layout_marginEnd">36dp</dimen>
+    <dimen name="fragment_rv_layout_height">200dp</dimen>
+    <dimen name="fragment_rv_marginTop">24dp</dimen>
+    <dimen name="fragment_rv_marginBottom">36dp</dimen>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,27 +8,40 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
+    <style name="ErrorMessageText">
+        <item name="android:padding">@dimen/error_message_padding</item>
+        <item name="android:textSize">@dimen/error_message_textSize</item>
+        <item name="android:visibility">invisible</item>
+    </style>
+
+    <style name="LoadingIndicator">
+        <item name="android:layout_width">@dimen/loading_indicator_size</item>
+        <item name="android:layout_height">@dimen/loading_indicator_size</item>
+        <item name="android:layout_gravity">center</item>
+        <item name="android:visibility">invisible</item>
+    </style>
+
     <style name="DetailTitleText">
         <item name="android:textColor">@color/colorWhite</item>
-        <item name="android:textSize">@dimen/title_text_size</item>
-        <item name="android:paddingLeft">@dimen/title_text_paddingLeft</item>
+        <item name="android:textSize">@dimen/title_textSize</item>
+        <item name="android:paddingLeft">@dimen/title_paddingLeft</item>
         <item name="android:textStyle">bold</item>
     </style>
 
     <style name="Poster">
         <item name="android:layout_width">@dimen/poster_layout_width</item>
         <item name="android:layout_height">@dimen/poster_layout_height</item>
-        <item name="android:layout_marginLeft">@dimen/poster_layout_marginLeft</item>
-        <item name="android:layout_marginStart">@dimen/poster_layout_marginStart</item>
+        <item name="android:layout_marginLeft">@dimen/default_margin</item>
+        <item name="android:layout_marginStart">@dimen/default_margin</item>
         <item name="android:layout_marginTop">@dimen/poster_layout_marginTop</item>
     </style>
 
     <style name="FavoriteStar">
         <item name="android:layout_width">@dimen/favorite_star_layout_width</item>
         <item name="android:layout_height">@dimen/favorite_star_layout_height</item>
-        <item name="android:layout_marginEnd">@dimen/favorite_star_layout_marginEnd</item>
-        <item name="android:layout_marginRight">@dimen/favorite_star_layout_marginRight</item>
-        <item name="android:layout_marginTop">@dimen/favorite_star_layout_marginTop</item>
+        <item name="android:layout_marginEnd">@dimen/default_margin</item>
+        <item name="android:layout_marginRight">@dimen/default_margin</item>
+        <item name="android:layout_marginTop">@dimen/default_margin</item>
     </style>
 
     <style name="MovieInfo">
@@ -41,25 +54,30 @@
 
     <style name="Summary">
         <item name="android:layout_marginBottom">@dimen/summary_layout_marginBottom</item>
-        <item name="android:layout_marginLeft">@dimen/summary_layout_marginLeft</item>
-        <item name="android:layout_marginStart">@dimen/summary_layout_marginStart</item>
-        <item name="android:layout_marginRight">@dimen/summary_layout_marginRight</item>
-        <item name="android:layout_marginEnd">@dimen/summary_layout_marginEnd</item>
         <item name="android:layout_marginTop">@dimen/summary_layout_marginTop</item>
+        <item name="android:layout_marginLeft">@dimen/default_margin</item>
+        <item name="android:layout_marginStart">@dimen/default_margin</item>
+        <item name="android:layout_marginRight">@dimen/default_margin</item>
+        <item name="android:layout_marginEnd">@dimen/default_margin</item>
     </style>
 
     <style name="FragmentHeader">
-        <item name="android:layout_marginLeft">@dimen/fragment_header_layout_marginLeft</item>
-        <item name="android:layout_marginStart">@dimen/fragment_header_layout_marginStart</item>
+        <item name="android:layout_marginLeft">@dimen/default_margin</item>
+        <item name="android:layout_marginStart">@dimen/default_margin</item>
         <item name="android:layout_marginTop">@dimen/fragment_header_layout_marginTop</item>
         <item name="android:textSize">@dimen/fragment_header_textSize</item>
         <item name="android:textStyle">bold</item>
     </style>
 
     <style name="Fragment">
-        <item name="android:layout_marginLeft">@dimen/fragment_layout_marginLeft</item>
-        <item name="android:layout_marginStart">@dimen/fragment_layout_marginStart</item>
-        <item name="android:layout_marginRight">@dimen/fragment_layout_marginRight</item>
-        <item name="android:layout_marginEnd">@dimen/fragment_layout_marginEnd</item>
+        <item name="android:layout_marginLeft">@dimen/default_margin</item>
+        <item name="android:layout_marginStart">@dimen/default_margin</item>
+        <item name="android:layout_marginRight">@dimen/default_margin</item>
+        <item name="android:layout_marginEnd">@dimen/default_margin</item>
+    </style>
+
+    <style name="FragmentScroll">
+        <item name="android:layout_height">@dimen/fragment_rv_layout_height</item>
+        <item name="android:layout_marginTop">@dimen/fragment_rv_marginTop</item>
     </style>
 </resources>


### PR DESCRIPTION
Fixes prior issue where navigation back from favorites DetailActivity would result in navigation being reset to `MOST_POPULAR` SortBy enum value instead of `FAVORITES`